### PR TITLE
Ebook validation

### DIFF
--- a/src/chapter_template.xhtml
+++ b/src/chapter_template.xhtml
@@ -18,7 +18,7 @@
         <section class="comment @!comment.moiety!@" id="cmt@!comment.cmt_id!@">
           <header class="comment-header-box">
             <!-- TODO: Avoid using tables for alignment -->
-            <table border=0> <tr> <td>
+            <table role="presentation"> <tr> <td>
                   <!--(if comment.HasField("icon_image_name"))-->
                     <img class="comment-image"
                          src="@!comment.icon_image_name!@"
@@ -42,7 +42,7 @@
           $!comment.text!$
         </section>
       <!--(end)-->
-      <hr />
+      </section>
     <!--(end)-->
   </body>
 </html>

--- a/src/gen_epub.py
+++ b/src/gen_epub.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     # Add Table of Contents.
     toc_epub = epub.EpubHtml(title="Table of Contents",
-                             file_name="nav.xhtml")
+                             file_name="toc.xhtml")
 
     with open("global_lists/toc.xhtml") as f:
         toc_epub.set_content(f.read())
@@ -100,6 +100,6 @@ if __name__ == "__main__":
         all_chapters.append(chapter_epub)
 
     book.add_item(epub.EpubNcx())
-    # book.add_item(epub.EpubNav())
+    book.add_item(epub.EpubNav())
 
     epub.write_epub("effulgence.epub", book, {})

--- a/src/gen_epub.py
+++ b/src/gen_epub.py
@@ -49,8 +49,10 @@ if __name__ == "__main__":
     book.set_identifier("effulgence_mirror")
     book.set_title("Effulgence")
     book.set_language("en")
-    book.add_author("Alicorn")
-    book.add_author("Kappa")
+    
+    # Each author needs a UID, or ebooklib gives them the same one.
+    book.add_author("Alicorn", uid="belltower")
+    book.add_author("Kappa", uid="binary-heat")
 
     all_chapters = []
 

--- a/src/gen_epub.py
+++ b/src/gen_epub.py
@@ -72,6 +72,9 @@ if __name__ == "__main__":
     toc_epub.add_item(css)
     book.add_item(toc_epub)
     book.spine = [toc_epub]
+    
+    # Also get EPUB TOC.
+    book.toc = [toc_epub]
 
     for introonly_chapter in chapters.chapter:
 
@@ -92,6 +95,7 @@ if __name__ == "__main__":
         chapter_epub.add_item(css)
         book.add_item(chapter_epub)
         book.spine.append(chapter_epub)
+        book.toc.append(chapter_epub)
 
         all_chapters.append(chapter_epub)
 

--- a/src/new_toc.py
+++ b/src/new_toc.py
@@ -25,7 +25,7 @@ if __name__== "__main__":
     the_toc_html = soup.select(".entry-content")[0]
 
     # Remove the "how to read" link.
-    the_toc_html.find_all("a")[0].extract()
+    the_toc_html.find_all("center")[0].extract()
 
     # As for the others, parse them & replace them with the appropriate internal
     # links.

--- a/src/toc_template.xhtml
+++ b/src/toc_template.xhtml
@@ -7,9 +7,7 @@
 
   <body>
     <nav>
-      <ol>
-        ${toc_entries}
-      </ol>
+      ${toc_entries}
     </nav>
   </body>
   


### PR DESCRIPTION
Take several steps towards making the generated epub file valid. For example, there is now a metadata TOC (not as good as the one still at the front of the book), and the authors don’t have the same xml id. Next steps include not assuming all images are jpegs (many of them are PNGs and a few are GIFs; the server tells us which, but it’s difficult-to-impossible to get wget to remember), and getting the ebook’s metadata TOC to better match the provided one (which may be hopeless, or at least require parsing the provided TOC more than we currently do).
